### PR TITLE
feat(backend): add MQTT service and FastAPI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,61 @@
+# OS
 .DS_Store
+Thumbs.db
+desktop.ini
 
-.idea
+# IDE
+.idea/
+.vscode/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# Environment / secrets
+.env
+.env.*
+!.env.example
+
+# Testing & type checkers
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+.tox/
+.nox/
+
+# Local databases (dev)
+*.sqlite3
+*.db
+
+# Logs
+*.log
+logs/
+
+# Docker (optional local overrides)
+docker-compose.override.yml

--- a/app/main.py
+++ b/app/main.py
@@ -17,11 +17,11 @@ app.include_router(task_router)
 @app.on_event("startup")
 async def on_startup() -> None:
     await init_models()
-    mqtt_service.start()
+    await mqtt_service.start()
 
 @app.on_event("shutdown")
 async def on_shutdown() -> None:
-    mqtt_service.stop()
+    await mqtt_service.stop()
 
 @app.get("/health")
 async def health() -> dict[str, str]:

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,19 @@
+from fastapi import FastAPI
+
+from app.routes.task_routes import router as task_router
+from core.mqtt_service import mqtt_service
+
+app = FastAPI(title="IoT Backend")
+app.include_router(task_router)
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    mqtt_service.start()
+
+@app.on_event("shutdown")
+async def on_shutdown() -> None:
+    mqtt_service.stop()
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,22 @@
+import logging
+
 from fastapi import FastAPI
 
 from app.routes.task_routes import router as task_router
 from core.mqtt_service import mqtt_service
+from core.database import init_models
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s"
+)
 
 app = FastAPI(title="IoT Backend")
 app.include_router(task_router)
 
 @app.on_event("startup")
 async def on_startup() -> None:
+    await init_models()
     mqtt_service.start()
 
 @app.on_event("shutdown")

--- a/app/routes/task_routes.py
+++ b/app/routes/task_routes.py
@@ -1,4 +1,3 @@
-import json
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -6,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from schemas.task_schema import TaskResponse, TaskCreate
 from models.task_model import Task
 from core.database import get_db
+from core.mqtt_service import mqtt_service
 
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
@@ -16,17 +16,19 @@ router = APIRouter(prefix="/tasks", tags=["tasks"])
     status_code=status.HTTP_201_CREATED,
     summary="Create a task",
 )
-async def create_task(body:TaskCreate, db:AsyncSession = Depends(get_db)) -> TaskResponse:
+async def create_task(body: TaskCreate, db: AsyncSession = Depends(get_db)) -> TaskResponse:
     task = Task(payload=body.payload)
     db.add(task)
     await db.flush()
     await db.refresh(task)
 
-    message = json.dumps({"task_id": str(task.id), "payload": task.payload})
-
-    '''
-    To implement: Send via MQTT 
-    '''
+    try:
+        mqtt_service.publish_task(task_id=task.id, payload=task.payload)
+    except RuntimeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=f"Task dispatch failed: {e}",
+        ) from e
 
     return TaskResponse.model_validate(task)
 
@@ -35,7 +37,7 @@ async def create_task(body:TaskCreate, db:AsyncSession = Depends(get_db)) -> Tas
     response_model=TaskResponse,
     summary="Get status and task result",
 )
-async def get_task(task_id: int, db:AsyncSession = Depends(get_db)) -> TaskResponse:
+async def get_task(task_id: int, db: AsyncSession = Depends(get_db)) -> TaskResponse:
     result = await db.execute(select(Task).where(Task.id == task_id))
     task = result.scalar_one_or_none()
 

--- a/app/routes/task_routes.py
+++ b/app/routes/task_routes.py
@@ -23,7 +23,7 @@ async def create_task(body: TaskCreate, db: AsyncSession = Depends(get_db)) -> T
     await db.refresh(task)
 
     try:
-        mqtt_service.publish_task(task_id=task.id, payload=task.payload)
+        await mqtt_service.publish_task(task_id=task.id, payload=task.payload)
     except RuntimeError as e:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,

--- a/app/routes/task_routes.py
+++ b/app/routes/task_routes.py
@@ -1,0 +1,48 @@
+import json
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from schemas.task_schema import TaskResponse, TaskCreate
+from models.task_model import Task
+from core.database import get_db
+
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+@router.post(
+    "/",
+    response_model=TaskResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a task",
+)
+async def create_task(body:TaskCreate, db:AsyncSession = Depends(get_db)) -> TaskResponse:
+    task = Task(payload=body.payload)
+    db.add(task)
+    await db.flush()
+    await db.refresh(task)
+
+    message = json.dumps({"task_id": str(task.id), "payload": task.payload})
+
+    '''
+    To implement: Send via MQTT 
+    '''
+
+    return TaskResponse.model_validate(task)
+
+@router.get(
+    "/{task_id}",
+    response_model=TaskResponse,
+    summary="Get status and task result",
+)
+async def get_task(task_id: int, db:AsyncSession = Depends(get_db)) -> TaskResponse:
+    result = await db.execute(select(Task).where(Task.id == task_id))
+    task = result.scalar_one_or_none()
+
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Task {task_id} non existent.",
+        )
+
+    return TaskResponse.model_validate(task)

--- a/core/config.py
+++ b/core/config.py
@@ -2,7 +2,20 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    #PostgreSQL
+    # PostgreSQL 
     DATABASE_URL: str = "postgresql+asyncpg://iot_user:iot_password@localhost:5432/iot_db"
+    DEBUG: bool = False
+
+    # MQTT Broker
+    MQTT_BROKER_HOST: str = "localhost"
+    MQTT_BROKER_PORT: int = 1883
+    MQTT_CLIENT_ID: str = "iot-backend"
+    MQTT_KEEPALIVE: int = 60
+    MQTT_QOS: int = 1
+
+    # MQTT Topics
+    MQTT_TASK_DISPATCH_TOPIC: str = "iot/task/dispatch"
+    MQTT_TASK_RESULT_TOPIC: str = "iot/task/result"
+    MQTT_DEVICE_HEARTBEAT_TOPIC: str = "iot/device/heartbeat"
 
 settings = Settings()

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,8 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    #PostgreSQL
+    DATABASE_URL: str = "postgresql+asyncpg://iot_user:iot_password@localhost:5432/iot_db"
+
+settings = Settings()

--- a/core/database.py
+++ b/core/database.py
@@ -3,6 +3,7 @@ from typing import AsyncGenerator
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from core.config import settings
+from models.task_model import Base
 
 engine = create_async_engine(
     settings.DATABASE_URL,
@@ -25,3 +26,7 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         except Exception:
             await session.rollback()
             raise
+
+async def init_models() -> None:
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)

--- a/core/database.py
+++ b/core/database.py
@@ -1,0 +1,27 @@
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from core.config import settings
+
+engine = create_async_engine(
+    settings.DATABASE_URL,
+    echo=settings.DEBUG,
+    pool_size=10,
+    max_overflow=20,
+)
+
+AsyncSessionLocal = async_sessionmaker(
+    bind=engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise

--- a/core/mqtt_service.py
+++ b/core/mqtt_service.py
@@ -1,96 +1,69 @@
+import asyncio
 import logging
 import json
 
-import paho.mqtt.client as mqtt
+from aiomqtt import Client, Message, MqttError
 
 from core.config import settings
 
 logger = logging.getLogger(__name__)
 
+
 class MqttService:
     def __init__(self) -> None:
-        self._client = mqtt.Client(client_id=settings.MQTT_CLIENT_ID)
-        self._is_started = False
-        self._client.on_connect = self._on_connect
-        self._client.on_message = self._on_message
+        self._client: Client | None = None
+        self._listener_task: asyncio.Task | None = None
+
 
     @property
     def is_started(self) -> bool:
-        return self._is_started
+        return self._client is not None
 
-    def start(self) -> None:
-        if self._is_started:
+
+    async def start(self) -> None:
+        if self.is_started:
             return
 
+        self._client = Client(
+            hostname=settings.MQTT_BROKER_HOST,
+            port=settings.MQTT_BROKER_PORT,
+            identifier=settings.MQTT_CLIENT_ID,
+            keepalive=settings.MQTT_KEEPALIVE,
+        )
+
         try:
-            self._client.connect(
-                host=settings.MQTT_BROKER_HOST,
-                port=settings.MQTT_BROKER_PORT,
-                keepalive=settings.MQTT_KEEPALIVE,
-            )
-            self._client.loop_start()
-        except OSError as e:
-            logger.error(
-                "MQTT connect failed (%s:%s): %s",
-                settings.MQTT_BROKER_HOST,
-                settings.MQTT_BROKER_PORT,
-                e,
-            )
+            await self._client.__aenter__()
+        except MqttError as e:
+            logger.error("MQTT connect failed: %s", e)
+            self._client = None
             raise
 
-        self._is_started = True
         logger.info("MQTT client started (%s:%s)", settings.MQTT_BROKER_HOST, settings.MQTT_BROKER_PORT)
 
-    def stop(self) -> None:
-        if not self._is_started:
-            return
-
-        self._client.loop_stop()
-        self._client.disconnect()
-        self._is_started = False
-        logger.info("MQTT client stopped")
-
-    def publish_task(self, task_id: int, payload: str) -> None:
-        if not self._is_started:
-            raise RuntimeError("MQTT client is not started")
-
-        message = {
-            "task_id": task_id,
-            "payload": payload,
-        }
-
-        result = self._client.publish(
-            topic=settings.MQTT_TASK_DISPATCH_TOPIC,
-            payload=json.dumps(message),
+        await self._client.subscribe(
+            topic=settings.MQTT_TASK_RESULT_TOPIC,
             qos=settings.MQTT_QOS,
         )
+        logger.info("MQTT client subscribed to topic=%s", settings.MQTT_TASK_RESULT_TOPIC)
 
-        if result.rc != mqtt.MQTT_ERR_SUCCESS:
-            raise RuntimeError(f"MQTT publish failed with error code: {result.rc}")
-        
-        logger.info(
-            "Task dispatched to MQTT topic=%s: message=%s",
-            settings.MQTT_TASK_DISPATCH_TOPIC,
-            message,
-        )
+        self._listener_task = asyncio.create_task(self._listen())
 
-    def _on_connect(self, client, _userdata, _flags, rc) -> None:
-        if rc != 0:
-            logger.error("MQTT connect failed with error code: %s", rc)
-            return
-        
-        client.subscribe(settings.MQTT_TASK_RESULT_TOPIC, qos=settings.MQTT_QOS)
-        logger.info("Subscribed to %s", settings.MQTT_TASK_RESULT_TOPIC)
-
-    def _on_message(self, _client, _userdata, msg) -> None:
-        if msg.topic != settings.MQTT_TASK_RESULT_TOPIC:
-            return
-        
+    
+    async def _listen(self) -> None:
         try:
-            decoded_payload = msg.payload.decode("utf-8")
+            async for message in self._client.messages:
+                if message.topic.matches(settings.MQTT_TASK_RESULT_TOPIC):
+                    await self._handle_result_message(message)
+        except MqttError as e:
+            logger.error("MQTT connection lost")
+
+
+    async def _handle_result_message(self, message: Message) -> None:
+        try:
+            decoded_payload = message.payload.decode("utf-8")
             data = json.loads(decoded_payload)
         except (UnicodeDecodeError, json.JSONDecodeError):
-            logger.warning("Invalid JSON payload received from topic=%s", msg.topic)
+            logger.warning("Invalid JSON payload received from topic=%s", message.topic)
             return
 
         task_id = data.get("task_id")
@@ -100,12 +73,45 @@ class MqttService:
         if task_id is None or task_status is None:
             logger.warning("Missing required fields in payload: %s", data)
             return
+        
+        logger.info("Task result received: task_id=%s, status=%s, result=%s", task_id, task_status, task_result)
 
-        logger.info(
-            "Task result received: task_id=%s, status=%s, result=%s",
-            task_id,
-            task_status,
-            task_result,
-        )
+
+    async def publish_task(self, task_id: int, payload: str) -> None:
+        if not self.is_started:
+            raise RuntimeError("MQTT client is not started")
+
+        message = {
+            "task_id": task_id,
+            "payload": payload,
+        }
+
+        try:
+            await self._client.publish(
+                topic=settings.MQTT_TASK_DISPATCH_TOPIC,
+                payload=json.dumps(message),
+                qos=settings.MQTT_QOS,
+            )
+        except MqttError as e:
+            raise RuntimeError(f"MQTT publish failed: {e}") from e
+
+        logger.info("Task dispatched to MQTT topic=%s: message=%s", settings.MQTT_TASK_DISPATCH_TOPIC, message)
+
+
+    async def stop(self) -> None:
+        if not self.is_started:
+            return
+
+        if self._listener_task:
+            self._listener_task.cancel()
+            try:
+                await self._listener_task
+            except asyncio.CancelledError:
+                pass
+
+        await self._client.__aexit__(None, None, None)
+        self._client = None
+        logger.info("MQTT client stopped")
+
 
 mqtt_service = MqttService()

--- a/core/mqtt_service.py
+++ b/core/mqtt_service.py
@@ -1,0 +1,105 @@
+import logging
+import json
+
+import paho.mqtt.client as mqtt
+
+from core.config import settings
+
+logger = logging.getLogger(__name__)
+
+class MqttService:
+    def __init__(self) -> None:
+        self._client = mqtt.Client(client_id=settings.MQTT_CLIENT_ID)
+        self._is_started = False
+        self._client.on_connect = self._on_connect
+        self._client.on_message = self._on_message
+
+    @property
+    def is_started(self) -> bool:
+        return self._is_started
+
+    def start(self) -> None:
+        if self._is_started:
+            return
+
+        try:
+            self._client.connect(
+                host=settings.MQTT_BROKER_HOST,
+                port=settings.MQTT_BROKER_PORT,
+                keepalive=settings.MQTT_KEEPALIVE,
+            )
+            self._client.loop_start()
+        except OSError as e:
+            logger.error(
+                "MQTT connect failed (%s:%s): %s",
+                settings.MQTT_BROKER_HOST,
+                settings.MQTT_BROKER_PORT,
+                e,
+            )
+            raise
+
+        self._is_started = True
+        logger.info("MQTT client started (%s:%s)", settings.MQTT_BROKER_HOST, settings.MQTT_BROKER_PORT)
+
+    def stop(self) -> None:
+        if not self._is_started:
+            return
+
+        self._client.loop_stop()
+        self._client.disconnect()
+        self._is_started = False
+        logger.info("MQTT client stopped")
+
+    def publish_task(self, task_id: int, payload: str) -> None:
+        if not self._is_started:
+            raise RuntimeError("MQTT client is not started")
+
+        message = {
+            "task_id": task_id,
+            "payload": payload,
+        }
+
+        result = self._client.publish(
+            topic=settings.MQTT_TASK_DISPATCH_TOPIC,
+            payload=json.dumps(message),
+            qos=settings.MQTT_QOS,
+        )
+
+        if result.rc != mqtt.MQTT_ERR_SUCCESS:
+            raise RuntimeError(f"MQTT publish failed with error code: {result.rc}")
+
+    def _on_connect(self, client, _userdata, _flags, rc) -> None:
+        if rc != 0:
+            logger.error("MQTT connect failed with error code: %s", rc)
+            return
+        
+        client.subscribe(settings.MQTT_TASK_RESULT_TOPIC, qos=settings.MQTT_QOS)
+        logger.info("Subscribed to %s", settings.MQTT_TASK_RESULT_TOPIC)
+
+    def _on_message(self, _client, _userdata, msg) -> None:
+        if msg.topic != settings.MQTT_TASK_RESULT_TOPIC:
+            return
+        
+        try:
+            decoded_payload = msg.payload.decode("utf-8")
+            data = json.loads(decoded_payload)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            logger.warning("Invalid JSON payload received from topic=%s", msg.topic)
+            return
+
+        task_id = data.get("task_id")
+        task_status = data.get("status")
+        task_result = data.get("result")
+        
+        if task_id is None or task_status is None:
+            logger.warning("Missing required fields in payload: %s", data)
+            return
+
+        logger.info(
+            "Task result received: task_id=%s, status=%s, result=%s",
+            task_id,
+            task_status,
+            task_result,
+        )
+
+mqtt_service = MqttService()

--- a/core/mqtt_service.py
+++ b/core/mqtt_service.py
@@ -67,6 +67,12 @@ class MqttService:
 
         if result.rc != mqtt.MQTT_ERR_SUCCESS:
             raise RuntimeError(f"MQTT publish failed with error code: {result.rc}")
+        
+        logger.info(
+            "Task dispatched to MQTT topic=%s: message=%s",
+            settings.MQTT_TASK_DISPATCH_TOPIC,
+            message,
+        )
 
     def _on_connect(self, client, _userdata, _flags, rc) -> None:
         if rc != 0:

--- a/core/mqtt_service.py
+++ b/core/mqtt_service.py
@@ -3,8 +3,11 @@ import logging
 import json
 
 from aiomqtt import Client, Message, MqttError
+from sqlalchemy import select
 
 from core.config import settings
+from core.database import AsyncSessionLocal
+from models.task_model import Task
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +78,29 @@ class MqttService:
             return
         
         logger.info("Task result received: task_id=%s, status=%s, result=%s", task_id, task_status, task_result)
+
+        await self._save_result(task_id=int(task_id), task_status=str(task_status), task_result=str(task_result))
+
+
+    async def _save_result(self, task_id: int, task_status: str, task_result: str) -> None:
+        async with AsyncSessionLocal() as session:
+            try:
+                result = await session.execute(
+                    select(Task).where(Task.id == task_id)
+                )
+                task = result.scalar_one_or_none()
+
+                if task is None:
+                    logger.warning("Task %s not found in DB", task_id)
+                    return
+                
+                task.status = task_status
+                task.result = task_result
+                await session.commit()
+                logger.info("Task %s updated: status=%s, result=%s", task_id, task_status, task_result)
+            except Exception:
+                await session.rollback()
+                raise
 
 
     async def publish_task(self, task_id: int, payload: str) -> None:

--- a/models/task_model.py
+++ b/models/task_model.py
@@ -1,4 +1,6 @@
-from sqlalchemy import Column, Integer, String
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, Integer, String
 from sqlalchemy.orm import DeclarativeBase
 
 #Base class for all SQLAlchemy models
@@ -10,6 +12,9 @@ class Task(Base):
     __tablename__ = "tasks"
 
     id = Column(Integer, primary_key=True)
-    status = Column(String)
-    payload = Column(String)
-    result = Column(String)
+    status = Column(String, nullable=False, default="queued")
+    payload = Column(String, nullable=False)
+    result = Column(String, nullable=True)
+    created_at = Column(DateTime(timezone=True),
+                                  nullable=False,
+                                  default=lambda: datetime.now(timezone.utc))

--- a/models/task_model.py
+++ b/models/task_model.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import DeclarativeBase
+
+class Base(DeclarativeBase):
+    pass
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True)
+    status = Column(String)
+    payload = Column(String)
+    result = Column(String)

--- a/models/task_model.py
+++ b/models/task_model.py
@@ -1,9 +1,11 @@
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import DeclarativeBase
 
+#Base class for all SQLAlchemy models
 class Base(DeclarativeBase):
     pass
 
+#Database table model for tasks
 class Task(Base):
     __tablename__ = "tasks"
 

--- a/models/task_model.py
+++ b/models/task_model.py
@@ -12,7 +12,7 @@ class Task(Base):
     __tablename__ = "tasks"
 
     id = Column(Integer, primary_key=True)
-    status = Column(String, nullable=False, default="queued")
+    status = Column(String, nullable=False, default="PENDING")
     payload = Column(String, nullable=False)
     result = Column(String, nullable=True)
     created_at = Column(DateTime(timezone=True),

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pydantic-settings
 uvicorn
 sqlalchemy
 asyncpg
-paho-mqtt
+aiomqtt
 pynacl

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+pydantic-settings
 uvicorn
 sqlalchemy
 asyncpg

--- a/schemas/task_schema.py
+++ b/schemas/task_schema.py
@@ -1,8 +1,10 @@
 from pydantic import BaseModel
 
+#Schema for incoming request - data sent by user
 class TaskCreate(BaseModel):
     payload: str
 
+#Schema for API responses - data returned to user
 class TaskResponse(BaseModel):
     id: int
     status: str

--- a/schemas/task_schema.py
+++ b/schemas/task_schema.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+class TaskCreate(BaseModel):
+    payload: str
+
+class TaskResponse(BaseModel):
+    id: int
+    status: str
+    payload: str
+    result: str | None
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
This pull request introduces the initial implementation of an asynchronous FastAPI backend for IoT task management, including task creation, retrieval, and MQTT-based communication with devices. The changes set up the core application structure, database models, API endpoints, MQTT integration, and configuration management.

**Core API and Application Setup:**
- Added the main FastAPI application in `app/main.py`, including startup and shutdown events to initialize the database and MQTT service, and a `/health` endpoint for health checks.
- Implemented task-related API endpoints in `app/routes/task_routes.py` for creating tasks (publishing them to MQTT) and retrieving task status/results.

**Database Layer:**
- Defined the `Task` SQLAlchemy model and base in `models/task_model.py`, representing tasks with fields for status, payload, result, and timestamps.
- Added asynchronous database initialization in `core/database.py`, including an `init_models` function for table creation.

**MQTT Integration:**
- Implemented `MqttService` in `core/mqtt_service.py` to handle MQTT client lifecycle, publish tasks to devices, and listen for task result messages to update the database.