### PR TITLE
Add database encryption

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,4 +13,6 @@ MQTT_TASK_RESULT_TOPIC=iot/task/result
 MQTT_DEVICE_HEARTBEAT_TOPIC=iot/device/heartbeat
 
 ENCRYPT_PAYLOAD=true
+ENCRYPT_DB=true
 NACL_SECRET_KEY=your_nacl_secret_key_here
+DB_ENCRYPTION_KEY=your_db_encryption_key_here

--- a/app/routes/task_routes.py
+++ b/app/routes/task_routes.py
@@ -11,7 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from core.config import settings
 from core.auth import get_current_user
-from schemas.task_schema import TaskResponse, TaskCreate
+from core.db_crypto import encrypt_db_value
+from schemas.task_schema import TaskResponse, TaskCreate, task_to_response
 from schemas.device_schema import DeviceResponse
 from schemas.operation_schema import OperationResponse, OperationCreate
 
@@ -151,7 +152,7 @@ async def create_and_dispatch_operation(
     )
 
     payload = expression
-    task = Task(payload=payload, user_id=current_user.id)
+    task = Task(payload=encrypt_db_value(payload), user_id=current_user.id)
     db.add(task)
     await db.flush()
     await db.refresh(task)
@@ -187,7 +188,7 @@ async def create_and_dispatch_operation(
 )
 async def create_task(body: TaskCreate, db: AsyncSession = Depends(get_db), current_user: User = Depends(get_current_user)) -> TaskResponse:
 
-    task = Task(payload=body.payload, user_id=current_user.id)
+    task = Task(payload=encrypt_db_value(body.payload), user_id=current_user.id)
     db.add(task)
     await db.flush()
     await db.refresh(task)
@@ -196,7 +197,7 @@ async def create_task(body: TaskCreate, db: AsyncSession = Depends(get_db), curr
     try:
         await mqtt_service.publish_task(
             task_id=task.id,
-            payload=task.payload,
+            payload=body.payload,
             user_id=current_user.id,
         )
     except RuntimeError as e:
@@ -205,7 +206,7 @@ async def create_task(body: TaskCreate, db: AsyncSession = Depends(get_db), curr
             detail=f"Task dispatch failed: {e}",
         ) from e
 
-    return TaskResponse.model_validate(task)
+    return task_to_response(task)
 
 @router.get(
     "/devices",
@@ -386,4 +387,4 @@ async def get_task(task_id: int, db: AsyncSession = Depends(get_db), current_use
             detail=f"Task {task_id} non existent.",
         )
 
-    return TaskResponse.model_validate(task)
+    return task_to_response(task)

--- a/app/routes/throttle.py
+++ b/app/routes/throttle.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Sequence
 from models.task_model import Task
+from core.db_crypto import decrypt_db_value
 from core.mqtt_service import mqtt_service
 
 BATCH_SIZE = 10  # number of tasks sent at once
@@ -11,7 +12,10 @@ async def dispatch_tasks_in_batches(tasks: Sequence[Task]) -> None:
     for i in range(0, len(tasks), BATCH_SIZE):
         batch = tasks[i:i + BATCH_SIZE]
         for task in batch:
-            await mqtt_service.publish_task(task_id=task.id, payload=task.payload)
+            await mqtt_service.publish_task(
+                task_id=task.id,
+                payload=decrypt_db_value(task.payload) or "",
+            )
         # wait before sending next batch to avoid overloading the agent
         if i + BATCH_SIZE < len(tasks):
             await asyncio.sleep(DELAY)

--- a/app/routes/upload_routes.py
+++ b/app/routes/upload_routes.py
@@ -6,9 +6,10 @@ from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.dialects.postgresql import insert
 
+from core.db_crypto import encrypt_db_value
 from core.database import get_db
 from models.task_model import Task
-from schemas.task_schema import TaskResponse
+from schemas.task_schema import TaskResponse, task_to_response
 from app.routes.throttle import dispatch_tasks_in_batches
 
 router = APIRouter(prefix="/tasks", tags=["upload"])
@@ -43,7 +44,10 @@ async def upload_tasks(
         )
 
     # bulk insert - save all tasks at once instead of one by one
-    payloads = [{"payload": item.get("payload", str(item))} for item in tasks_data]
+    payloads = [
+        {"payload": encrypt_db_value(str(item.get("payload", str(item))))}
+        for item in tasks_data
+    ]
     result = await db.execute(
         insert(Task).returning(Task),
         payloads,
@@ -51,4 +55,4 @@ async def upload_tasks(
     created_tasks = result.scalars().all()
 
     await dispatch_tasks_in_batches(created_tasks)
-    return [TaskResponse.model_validate(task) for task in created_tasks]
+    return [task_to_response(task) for task in created_tasks]

--- a/core/config.py
+++ b/core/config.py
@@ -29,5 +29,7 @@ class Settings(BaseSettings):
 
     NACL_SECRET_KEY: str = ""
     ENCRYPT_PAYLOAD: bool = True
+    ENCRYPT_DB: bool = True
+    DB_ENCRYPTION_KEY: str = ""
 
 settings = Settings()

--- a/core/db_crypto.py
+++ b/core/db_crypto.py
@@ -1,0 +1,55 @@
+import base64
+from binascii import Error as Base64Error
+
+from nacl.exceptions import CryptoError
+from nacl.secret import SecretBox
+
+from core.config import settings
+
+DB_ENCRYPTION_PREFIX = "db:v1:"
+
+
+def _get_secret_box() -> SecretBox:
+    key_hex = settings.DB_ENCRYPTION_KEY
+    if not key_hex:
+        raise RuntimeError("DB_ENCRYPTION_KEY not set in environment")
+
+    try:
+        key = bytes.fromhex(key_hex)
+    except ValueError as exc:
+        raise RuntimeError("DB_ENCRYPTION_KEY must be a hex string") from exc
+
+    if len(key) != SecretBox.KEY_SIZE:
+        raise RuntimeError("DB_ENCRYPTION_KEY must be 32 bytes encoded as 64 hex characters")
+
+    return SecretBox(key)
+
+
+def encrypt_db_value(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    if not settings.ENCRYPT_DB:
+        return value
+
+    if value.startswith(DB_ENCRYPTION_PREFIX):
+        return value
+
+    encrypted = _get_secret_box().encrypt(value.encode("utf-8"))
+    encoded = base64.b64encode(encrypted).decode("utf-8")
+    return f"{DB_ENCRYPTION_PREFIX}{encoded}"
+
+
+def decrypt_db_value(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    if not value.startswith(DB_ENCRYPTION_PREFIX):
+        return value
+
+    encoded = value.removeprefix(DB_ENCRYPTION_PREFIX)
+    try:
+        encrypted = base64.b64decode(encoded.encode("utf-8"))
+        return _get_secret_box().decrypt(encrypted).decode("utf-8")
+    except (Base64Error, ValueError, CryptoError) as exc:
+        raise RuntimeError("Unable to decrypt database value") from exc

--- a/core/mqtt_service.py
+++ b/core/mqtt_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from core.websocket_manager import WebSocketManager
 from core.config import settings
 from core.database import AsyncSessionLocal
+from core.db_crypto import decrypt_db_value, encrypt_db_value
 from models.device_model import Device
 from models.task_model import Task
 
@@ -222,11 +223,11 @@ class MqttService:
                     return
                 
                 task.status = task_status
-                task.result = task_result
+                task.result = encrypt_db_value(task_result)
                 await session.commit()
                 payload_device_id = device_id
                 try:
-                    payload = json.loads(task.payload)
+                    payload = json.loads(decrypt_db_value(task.payload) or "")
                     payload_device_id = payload_device_id or payload.get("device_id")
                 except (TypeError, json.JSONDecodeError, AttributeError):
                     pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,14 +28,10 @@ services:
     depends_on:
       - postgres
       - mosquitto
+    env_file:
+      - .env
     environment:
       DATABASE_URL: postgresql+asyncpg://iot_user:iot_password@postgres:5432/iot_db
-      SECRET_KEY: ${SECRET_KEY}
-      NACL_SECRET_KEY: ${NACL_SECRET_KEY}
-      DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY}
-      ENCRYPT_PAYLOAD: ${ENCRYPT_PAYLOAD}
-      ENCRYPT_DB: ${ENCRYPT_DB}
-      DEBUG: ${DEBUG}
       MQTT_BROKER_HOST: mosquitto
       MQTT_BROKER_PORT: 1883
       MQTT_CLIENT_ID: iot-backend
@@ -57,6 +53,8 @@ services:
     depends_on:
       - mosquitto
       - backend
+    env_file:
+      - .env
     environment:
       DEVICE_ID: rpi-agent-001
       MQTT_BROKER_HOST: mosquitto
@@ -66,8 +64,6 @@ services:
       MQTT_DEVICE_HEARTBEAT_TOPIC: iot/device/heartbeat
       WORKER_COUNT: 2
       HEARTBEAT_INTERVAL_SECONDS: 5
-      NACL_SECRET_KEY: ${NACL_SECRET_KEY}
-      ENCRYPT_PAYLOAD: ${ENCRYPT_PAYLOAD}
     volumes:
       - agent_1_keys:/app/keys
 
@@ -80,6 +76,8 @@ services:
     depends_on:
       - mosquitto
       - backend
+    env_file:
+      - .env
     environment:
       DEVICE_ID: rpi-agent-002
       MQTT_BROKER_HOST: mosquitto
@@ -89,8 +87,6 @@ services:
       MQTT_DEVICE_HEARTBEAT_TOPIC: iot/device/heartbeat
       WORKER_COUNT: 2
       HEARTBEAT_INTERVAL_SECONDS: 5
-      NACL_SECRET_KEY: ${NACL_SECRET_KEY}
-      ENCRYPT_PAYLOAD: ${ENCRYPT_PAYLOAD}
     volumes:
       - agent_2_keys:/app/keys
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,9 @@ services:
       DATABASE_URL: postgresql+asyncpg://iot_user:iot_password@postgres:5432/iot_db
       SECRET_KEY: ${SECRET_KEY}
       NACL_SECRET_KEY: ${NACL_SECRET_KEY}
+      DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY}
       ENCRYPT_PAYLOAD: ${ENCRYPT_PAYLOAD}
+      ENCRYPT_DB: ${ENCRYPT_DB}
       DEBUG: ${DEBUG}
       MQTT_BROKER_HOST: mosquitto
       MQTT_BROKER_PORT: 1883

--- a/schemas/task_schema.py
+++ b/schemas/task_schema.py
@@ -1,10 +1,15 @@
 from pydantic import BaseModel
 
-#Schema for incoming request - data sent by user
+from core.db_crypto import decrypt_db_value
+from models.task_model import Task
+
+
+# Schema for incoming request - data sent by user
 class TaskCreate(BaseModel):
     payload: str
 
-#Schema for API responses - data returned to user
+
+# Schema for API responses - data returned to user
 class TaskResponse(BaseModel):
     id: int
     user_id: int
@@ -14,3 +19,13 @@ class TaskResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+def task_to_response(task: Task) -> TaskResponse:
+    return TaskResponse(
+        id=task.id,
+        user_id=task.user_id,
+        status=task.status,
+        payload=decrypt_db_value(task.payload) or "",
+        result=decrypt_db_value(task.result),
+    )

--- a/tests/test_db_crypto.py
+++ b/tests/test_db_crypto.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from core.config import settings
+from core.db_crypto import DB_ENCRYPTION_PREFIX, decrypt_db_value, encrypt_db_value
+from schemas.task_schema import task_to_response
+
+
+def test_encrypt_db_value_roundtrip(monkeypatch):
+    monkeypatch.setattr(settings, "DB_ENCRYPTION_KEY", "00" * 32)
+
+    encrypted = encrypt_db_value("2+2")
+
+    assert encrypted is not None
+    assert encrypted.startswith(DB_ENCRYPTION_PREFIX)
+    assert encrypted != "2+2"
+    assert decrypt_db_value(encrypted) == "2+2"
+
+
+def test_encrypt_db_value_does_not_encrypt_twice(monkeypatch):
+    monkeypatch.setattr(settings, "DB_ENCRYPTION_KEY", "00" * 32)
+
+    encrypted = encrypt_db_value("2+2")
+
+    assert encrypt_db_value(encrypted) == encrypted
+
+
+def test_decrypt_db_value_keeps_legacy_plaintext():
+    assert decrypt_db_value("legacy payload") == "legacy payload"
+
+
+def test_encrypt_db_value_respects_encrypt_db_toggle(monkeypatch):
+    monkeypatch.setattr(settings, "DB_ENCRYPTION_KEY", "00" * 32)
+    encrypted = encrypt_db_value("2+2")
+
+    monkeypatch.setattr(settings, "ENCRYPT_DB", False)
+
+    assert encrypt_db_value("3+3") == "3+3"
+    assert decrypt_db_value(encrypted) == "2+2"
+
+
+def test_task_to_response_decrypts_task_fields(monkeypatch):
+    monkeypatch.setattr(settings, "DB_ENCRYPTION_KEY", "00" * 32)
+    task = SimpleNamespace(
+        id=1,
+        user_id=2,
+        status="completed",
+        payload=encrypt_db_value("2+2"),
+        result=encrypt_db_value("4.0"),
+    )
+
+    response = task_to_response(task)
+
+    assert response.payload == "2+2"
+    assert response.result == "4.0"

--- a/tests/test_throttle.py
+++ b/tests/test_throttle.py
@@ -1,5 +1,8 @@
-import pytest
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from core.config import settings
+from core.db_crypto import encrypt_db_value
 from app.routes.throttle import dispatch_tasks_in_batches
 
 def make_task(task_id: int, payload: str):
@@ -9,25 +12,27 @@ def make_task(task_id: int, payload: str):
     task.payload = payload
     return task
 
-@pytest.mark.asyncio
-async def test_dispatch_in_batches():
+def test_dispatch_in_batches(monkeypatch):
+    monkeypatch.setattr(settings, "DB_ENCRYPTION_KEY", "00" * 32)
     # create 25 mock tasks
-    tasks = [make_task(i, f"payload_{i}") for i in range(25)]
+    tasks = [make_task(i, encrypt_db_value(f"payload_{i}")) for i in range(25)]
 
     with patch("app.routes.throttle.mqtt_service") as mock_mqtt:
         mock_mqtt.publish_task = AsyncMock()
 
         with patch("app.routes.throttle.asyncio.sleep", new_callable=AsyncMock):
-            await dispatch_tasks_in_batches(tasks)
+            asyncio.run(dispatch_tasks_in_batches(tasks))
 
     # check that publish_task was called 25 times
     assert mock_mqtt.publish_task.call_count == 25
+    mock_mqtt.publish_task.assert_any_await(task_id=0, payload="payload_0")
+    mock_mqtt.publish_task.assert_any_await(task_id=24, payload="payload_24")
 
-@pytest.mark.asyncio
-async def test_dispatch_empty_list():
+
+def test_dispatch_empty_list():
     # check that empty list does not cause errors
     with patch("app.routes.throttle.mqtt_service") as mock_mqtt:
         mock_mqtt.publish_task = AsyncMock()
-        await dispatch_tasks_in_batches([])
+        asyncio.run(dispatch_tasks_in_batches([]))
 
     assert mock_mqtt.publish_task.call_count == 0


### PR DESCRIPTION
## Summary

- Add field-level encryption for task payloads and results stored in PostgreSQL.
- Add `ENCRYPT_DB` and `DB_ENCRYPTION_KEY` configuration to control database encryption independently from MQTT transport encryption.
- Load shared runtime secrets from `.env` via Docker Compose `env_file` to avoid stale shell environment overrides.

## Test plan

- `python -m pytest tests/test_db_crypto.py tests/test_agent.py tests/test_throttle.py`
- Verified that `tasks.payload` and `tasks.result` are stored as `db:v1:...` when `ENCRYPT_DB=true`.
- Verified that API responses still return decrypted payload/result values.